### PR TITLE
Add option to control empty tag collapsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "@stable"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "./"
     ],
     "require": {
-        "pear/pear-core-minimal": "^1.9.5"
+        "php": ">=5.4",
+        "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
         "phpunit/phpunit": "@stable"

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "pear/pear-core-minimal": "^1.10.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "@stable"
+        "phpunit/phpunit": "<6.0"
     }
 }

--- a/package.xml
+++ b/package.xml
@@ -22,8 +22,8 @@
   <email>davey@php.net</email>
   <active>no</active>
  </helper>
- <date>2017-01-29</date>
- <time>11:40:00</time>
+ <date>2017-02-03</date>
+ <time>10:20:00</time>
  <version>
   <release>1.4.0a1</release>
   <api>1.4.0</api>
@@ -37,6 +37,11 @@
  <notes>
 * Set minimum PHP version to 5.4.0
 * Set minimum PEAR version to 1.10.1
+
+* Adds a new XML_UTIL_COLLAPSE_NONE option
+  for preventing empty tag collapsing.
+
+* Request #15467 CDATA sections and blank nodes
  </notes>
 
  <contents>
@@ -537,11 +542,16 @@ Bug #20293	Broken installation for 1.2.2
     <release>alpha</release>
     <api>stable</api>
    </stability>
-   <date>2017-01-29</date>
+   <date>2017-02-03</date>
    <license uri="http://opensource.org/licenses/bsd-license">BSD License</license>
    <notes>
 * Set minimum PHP version to 5.4.0
 * Set minimum PEAR version to 1.10.1
+
+* Adds a new XML_UTIL_COLLAPSE_NONE option
+  for preventing empty tag collapsing.
+
+* Request #15467 CDATA sections and blank nodes
    </notes>
   </release>
 

--- a/tests/AbstractUnitTests.php
+++ b/tests/AbstractUnitTests.php
@@ -1,7 +1,13 @@
 <?php
-use PHPUnit\Framework\TestCase;
 
-abstract class AbstractUnitTests extends TestCase
+/*
+ * Allow for PHPUnit 4.* while XML_Util is still usable on PHP 5.4
+ */
+if (!class_exists('PHPUnit_Framework_TestCase')) {
+    class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+}
+
+abstract class AbstractUnitTests extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/tests/AbstractUnitTests.php
+++ b/tests/AbstractUnitTests.php
@@ -1,6 +1,7 @@
 <?php
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractUnitTests extends \PHPUnit_Framework_TestCase
+abstract class AbstractUnitTests extends TestCase
 {
     public function setUp()
     {

--- a/tests/CollapseEmptyTagsTests.php
+++ b/tests/CollapseEmptyTagsTests.php
@@ -98,4 +98,25 @@ class CollapseEmptyTagsTests extends AbstractUnitTests
         $expected = "<foo></foo><br /><bar>baz</bar>";
         $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $xhtmlTag . $otherTag, XML_UTIL_COLLAPSE_XHTML_ONLY));
     }
+
+    /**
+     * @covers XML_Util::collapseEmptyTags()
+     */
+    public function testCollapseEmptyTagsOnOneEmptyTagWithCollapseNone()
+    {
+        $emptyTag = "<foo></foo>";
+        $expected = "<foo></foo>";
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag, XML_UTIL_COLLAPSE_NONE));
+    }
+
+    /**
+     * @covers XML_Util::collapseEmptyTags()
+     */
+    public function testCollapseEmptyTagsOnOneEmptyTagAlongsideNonemptyTagWithCollapseNone()
+    {
+        $emptyTag = "<foo></foo>";
+        $otherTag = "<bar>baz</bar>";
+        $expected = "<foo></foo><bar>baz</bar>";
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $otherTag, XML_UTIL_COLLAPSE_NONE));
+    }
 }

--- a/tests/CollapseEmptyTagsTests.php
+++ b/tests/CollapseEmptyTagsTests.php
@@ -61,8 +61,8 @@ class CollapseEmptyTagsTests extends AbstractUnitTests
     {
         $emptyTag = "<foo></foo>";
         $otherTag = "<bar>baz</bar>";
-        $xhtmlTag = "<b></b>";
-        $expected = "<foo></foo><b></b><bar>baz</bar>";
+        $xhtmlTag = "<br></br>";
+        $expected = "<foo></foo><br /><bar>baz</bar>";
         $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $xhtmlTag . $otherTag, XML_UTIL_COLLAPSE_XHTML_ONLY));
     }
 }

--- a/tests/CollapseEmptyTagsTests.php
+++ b/tests/CollapseEmptyTagsTests.php
@@ -47,6 +47,39 @@ class CollapseEmptyTagsTests extends AbstractUnitTests
     /**
      * @covers XML_Util::collapseEmptyTags()
      */
+    public function testCollapseEmptyTagsOnOneEmptyTagAlongsideNonemptyTagAlongsideEmptyTagWithCollapseAll()
+    {
+        $emptyTag = "<foo></foo>";
+        $otherTag = "<bar>baz</bar>";
+        $expected = "<foo /><bar>baz</bar><foo />";
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $otherTag . $emptyTag, XML_UTIL_COLLAPSE_ALL));
+    }
+
+    /**
+     * @covers XML_Util::collapseEmptyTags()
+     */
+    public function testCollapseEmptyTagsOnOneEmptyPrefixedTagAlongsideNonemptyTagAlongsideEmptyPrefixedTagWithCollapseAll()
+    {
+        $emptyTag = "<foo:foo2></foo:foo2>";
+        $otherTag = "<bar>baz</bar>";
+        $expected = "<foo:foo2 /><bar>baz</bar><foo:foo2 />";
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $otherTag . $emptyTag, XML_UTIL_COLLAPSE_ALL));
+    }
+
+    /**
+     * @covers XML_Util::collapseEmptyTags()
+     */
+    public function testCollapseEmptyTagsOnOneEmptyNsPrefixedTagAlongsideNonemptyTagAlongsideEmptyNsPrefixedTagWithCollapseAll()
+    {
+        $emptyTag = "<http://foo.com:foo2></http://foo.com:foo2>";
+        $otherTag = "<bar>baz</bar>";
+        $expected = "<http://foo.com:foo2 /><bar>baz</bar><http://foo.com:foo2 />";
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($emptyTag . $otherTag . $emptyTag, XML_UTIL_COLLAPSE_ALL));
+    }
+
+    /**
+     * @covers XML_Util::collapseEmptyTags()
+     */
     public function testCollapseEmptyTagsOnOneEmptyTagWithCollapseXhtml()
     {
         $emptyTag = "<foo></foo>";

--- a/tests/CreateTagFromArrayTests.php
+++ b/tests/CreateTagFromArrayTests.php
@@ -322,6 +322,25 @@ EOF;
     /**
      * @covers XML_Util::createTagFromArray()
      */
+    public function testCreateTagFromArrayWithImplicitlyEmptyContentAndCollapseNoneDoesNotCollapseTag()
+    {
+        $original = array('qname' => 'tag1');
+        $expected = "<tag1></tag1>";
+        $actual = XML_Util::createTagFromArray(
+            $original,
+            XML_UTIL_REPLACE_ENTITIES,  // default $replaceEntities
+            false,                      // default $multiline
+            '_auto',                    // default $indent
+            "\n",                       // default $linebreak
+            true,                       // default $sortAttributes
+            XML_UTIL_COLLAPSE_NONE
+        );
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers XML_Util::createTagFromArray()
+     */
     public function testCreateTagFromArrayForCdataWithExplicitlyEmptyContentDoesNotCollapseTag()
     {
         $original = array('qname' => 'tag1', 'content' => '');

--- a/tests/CreateTagFromArrayTests.php
+++ b/tests/CreateTagFromArrayTests.php
@@ -318,4 +318,14 @@ EOF;
         $expected = "<bar />";
         $this->assertEquals($expected, XML_Util::createTagFromArray($original));
     }
+
+    /**
+     * @covers XML_Util::createTagFromArray()
+     */
+    public function testCreateTagFromArrayForCdataWithExplicitlyEmptyContentDoesNotCollapseTag()
+    {
+        $original = array('qname' => 'tag1', 'content' => '');
+        $expected = "<tag1><![CDATA[]]></tag1>";
+        $this->assertEquals($expected, XML_Util::createTagFromArray($original, XML_UTIL_CDATA_SECTION));
+    }
 }


### PR DESCRIPTION
This addition should handle Request# 15467 (https://pear.php.net/bugs/bug.php?id=15467).

This also fixes the PREGs in `collapseEmptyTags()` so that it can handle prefixed tags (e.g. `<foo:bar>`, `<http://foo.com:bar>`).