### PR TITLE
PREG erroring in PHP 5

### DIFF
--- a/XML/Util.php
+++ b/XML/Util.php
@@ -459,6 +459,10 @@ class XML_Util
      */
     public static function collapseEmptyTags($xml, $mode = XML_UTIL_COLLAPSE_ALL)
     {
+        if (preg_match('~<([^>])+/>~s', $xml, $matches)) {
+            // it's already an empty tag
+            return $xml;
+        }
         switch ($mode) {
             case XML_UTIL_COLLAPSE_ALL:
                 $preg1 =

--- a/XML/Util.php
+++ b/XML/Util.php
@@ -470,12 +470,12 @@ class XML_Util
                         ')+' .
                         '([^>]*)' .                     // attributes           ($4)
                     '>' .
-                    '<\/(\1|\2|\3)>' .
+                    '<\/(\1|\2|\3)>' .                  // 1, 2, or 3 again     ($5)
                     '~s'
                 ;
                 $preg2 =
                     '<' .
-                        '${1}${2}${3}' .    // tag
+                        '${1}${2}${3}' .    // tag (only one should have been populated)
                         '${4}' .            // attributes
                     ' />'
                 ;

--- a/package.xml
+++ b/package.xml
@@ -22,8 +22,8 @@
   <email>davey@php.net</email>
   <active>no</active>
  </helper>
- <date>2017-02-06</date>
- <time>14:30:00</time>
+ <date>2017-02-07</date>
+ <time>12:00:00</time>
  <version>
   <release>1.4.1</release>
   <api>1.4.0</api>
@@ -559,7 +559,7 @@ Bug #20293	Broken installation for 1.2.2
     <release>stable</release>
     <api>stable</api>
    </stability>
-   <date>2017-02-06</date>
+   <date>2017-02-07</date>
    <license uri="http://opensource.org/licenses/bsd-license">BSD License</license>
    <notes>
 * Bug #21177 XML_Util::collapseEmptyTags() can return NULL

--- a/package.xml
+++ b/package.xml
@@ -22,10 +22,10 @@
   <email>davey@php.net</email>
   <active>no</active>
  </helper>
- <date>2017-02-03</date>
- <time>12:30:00</time>
+ <date>2017-02-06</date>
+ <time>14:30:00</time>
  <version>
-  <release>1.4.0</release>
+  <release>1.4.1</release>
   <api>1.4.0</api>
  </version>
  <stability>
@@ -35,13 +35,7 @@
  <license uri="http://opensource.org/licenses/bsd-license">BSD License</license>
 
  <notes>
-* Set minimum PHP version to 5.4.0
-* Set minimum PEAR version to 1.10.1
-
-* Adds a new XML_UTIL_COLLAPSE_NONE option
-  for preventing empty tag collapsing.
-
-* Request #15467 CDATA sections and blank nodes
+* Bug #21177 XML_Util::collapseEmptyTags() can return NULL
  </notes>
 
  <contents>
@@ -68,6 +62,7 @@
    <file baseinstalldir="/" name="tests/Bug4950Tests.php" role="test" />
    <file baseinstalldir="/" name="tests/Bug5392Tests.php" role="test" />
    <file baseinstalldir="/" name="tests/Bug18343Tests.php" role="test" />
+   <file baseinstalldir="/" name="tests/Bug21177Tests.php" role="test" />
    <file baseinstalldir="/" name="XML/Util.php" role="php">
     <tasks:replace from="@version@" to="version" type="package-info" />
    </file>
@@ -552,6 +547,22 @@ Bug #20293	Broken installation for 1.2.2
   for preventing empty tag collapsing.
 
 * Request #15467 CDATA sections and blank nodes
+   </notes>
+  </release>
+
+  <release>
+   <version>
+    <release>1.4.1</release>
+    <api>1.4.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2017-02-06</date>
+   <license uri="http://opensource.org/licenses/bsd-license">BSD License</license>
+   <notes>
+* Bug #21177 XML_Util::collapseEmptyTags() can return NULL
    </notes>
   </release>
 

--- a/tests/Bug21177Tests.php
+++ b/tests/Bug21177Tests.php
@@ -15,11 +15,11 @@ class Bug21177Tests extends AbstractUnitTests
         $expected = '<id_mytest_yesorno />';
 
         return array(
-            array('<id_mytest_yesorno></id_mytest_yesorno>', '<id_mytest_yesorno />'),
-            array('<id_mytest_yesorno />', '<id_mytest_yesorno />'),
+            array('<idmytestyesorno></idmytestyesorno>',        '<idmytestyesorno />'),
+            array('<idmytestyesorno />',                        '<idmytestyesorno />'),
 
-            array('<idmytestyesorno></idmytestyesorno>', '<idmytestyesorno />'),
-            array('<idmytestyesorno />', '<idmytestyesorno />'),
+            array('<id_mytest_yesorno></id_mytest_yesorno>',    '<id_mytest_yesorno />'),
+            array('<id_mytest_yesorno />',                      '<id_mytest_yesorno />'),
         );
     }
 

--- a/tests/Bug21177Tests.php
+++ b/tests/Bug21177Tests.php
@@ -3,10 +3,10 @@
 /**
  * Bug #21177 "XML_Util::collapseEmptyTags() can return NULL"
  *
- * Original characters of the given encoding that are "replaced"
- * should then "reverse" back to perfectly match the original.
+ * PREG returns NULL when it encounters an error.
+ * In this case, it was encountering PREG_BACKTRACK_LIMIT_ERROR.
  *
- * @link https://pear.php.net/bugs/bug.php?id=5392
+ * @link https://pear.php.net/bugs/bug.php?id=21177
  */
 class Bug21177Tests extends AbstractUnitTests
 {

--- a/tests/Bug21177Tests.php
+++ b/tests/Bug21177Tests.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Bug #21177 "XML_Util::collapseEmptyTags() can return NULL"
+ *
+ * Original characters of the given encoding that are "replaced"
+ * should then "reverse" back to perfectly match the original.
+ *
+ * @link https://pear.php.net/bugs/bug.php?id=5392
+ */
+class Bug21177Tests extends AbstractUnitTests
+{
+    public function getTestCandidate()
+    {
+        $expected = '<id_mytest_yesorno />';
+
+        return array(
+            array('<id_mytest_yesorno></id_mytest_yesorno>', '<id_mytest_yesorno />'),
+            array('<id_mytest_yesorno />', '<id_mytest_yesorno />'),
+
+            array('<idmytestyesorno></idmytestyesorno>', '<idmytestyesorno />'),
+            array('<idmytestyesorno />', '<idmytestyesorno />'),
+        );
+    }
+
+    /**
+     * @dataProvider getTestCandidate()
+     */
+    public function testCollapseEmptyTagsForBug21177($original, $expected)
+    {
+        $this->assertEquals($expected, XML_Util::collapseEmptyTags($original, XML_UTIL_COLLAPSE_ALL), "Failed bugcheck.");
+    }
+}


### PR DESCRIPTION
https://pear.php.net/bugs/bug.php?id=21177

PREG was erroring on an already empty tag that contains underscores in the tag name.

Added recognition that if the passed in tag is already empty, it can be returned as is.