### PR TITLE
Fix #21184, collapseEmptyTags breaks XML_Serializer

### DIFF
--- a/XML/Util.php
+++ b/XML/Util.php
@@ -483,7 +483,7 @@ class XML_Util
                         '${4}' .            // attributes
                     ' />'
                 ;
-                return preg_replace($preg1, $preg2, $xml);
+                return (preg_replace($preg1, $preg2, $xml)?:$xml);
                 break;
             case XML_UTIL_COLLAPSE_XHTML_ONLY:
                 return preg_replace(

--- a/package.xml
+++ b/package.xml
@@ -63,6 +63,7 @@
    <file baseinstalldir="/" name="tests/Bug5392Tests.php" role="test" />
    <file baseinstalldir="/" name="tests/Bug18343Tests.php" role="test" />
    <file baseinstalldir="/" name="tests/Bug21177Tests.php" role="test" />
+   <file baseinstalldir="/" name="tests/Bug21184Tests.php" role="test" />
    <file baseinstalldir="/" name="XML/Util.php" role="php">
     <tasks:replace from="@version@" to="version" type="package-info" />
    </file>

--- a/tests/Bug21184Tests.php
+++ b/tests/Bug21184Tests.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Bug #21184
+ *
+ * PREG returns NULL when it encounters an error.
+ * In this case, it was encountering PREG_BACKTRACK_LIMIT_ERROR.
+ *
+ * @link https://pear.php.net/bugs/bug.php?id=21177
+ */
+class Bug21184 extends AbstractUnitTests
+{
+    public function testBug21184()
+    {
+        $xml = '<XML_Serializer_Tag>one</XML_Serializer_Tag>';
+        $this->assertEquals($xml, XML_Util::collapseEmptyTags($xml, XML_UTIL_COLLAPSE_ALL));
+    }
+}


### PR DESCRIPTION
See: https://github.com/pear/XML_Serializer/pull/3
