### PR TITLE
fix phplint warning

### DIFF
--- a/XML/Util.php
+++ b/XML/Util.php
@@ -918,7 +918,7 @@ class XML_Util
     public static function isValidName($string)
     {
         // check for invalid chars
-        if (!preg_match('/^[[:alpha:]_]\\z/', $string{0})) {
+        if (!preg_match('/^[[:alpha:]_]\\z/', $string[0])) {
             return XML_Util::raiseError(
                 'XML names may only start with letter or underscore',
                 XML_UTIL_ERROR_INVALID_START


### PR DESCRIPTION
With 7.4.0

```
$ find . -name \*.php -exec php -l {} \;
No syntax errors detected in ./package.php
No syntax errors detected in ./examples/example2.php
No syntax errors detected in ./examples/example.php
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in ./XML/Util.php on line 921
No syntax errors detected in ./XML/Util.php
No syntax errors detected in ./tests/ReverseEntitiesTests.php
No syntax errors detected in ./tests/ReplaceEntitiesTests.php
No syntax errors detected in ./tests/AttributesToStringTests.php
No syntax errors detected in ./tests/Bug21184Tests.php
No syntax errors detected in ./tests/CreateTagFromArrayTests.php
No syntax errors detected in ./tests/Bug4950Tests.php
No syntax errors detected in ./tests/GetXmlDeclarationTests.php
No syntax errors detected in ./tests/RaiseErrorTests.php
No syntax errors detected in ./tests/SplitQualifiedNameTests.php
No syntax errors detected in ./tests/CreateCommentTests.php
No syntax errors detected in ./tests/CreateStartElementTests.php
No syntax errors detected in ./tests/Bug18343Tests.php
No syntax errors detected in ./tests/Bug21177Tests.php
No syntax errors detected in ./tests/ApiVersionTests.php
No syntax errors detected in ./tests/CollapseEmptyTagsTests.php
No syntax errors detected in ./tests/IsValidNameTests.php
No syntax errors detected in ./tests/CreateEndElementTests.php
No syntax errors detected in ./tests/CreateTagTests.php
No syntax errors detected in ./tests/GetDocTypeDeclarationTests.php
No syntax errors detected in ./tests/AbstractUnitTests.php
No syntax errors detected in ./tests/Bug5392Tests.php
No syntax errors detected in ./tests/CreateCDataSectionTests.php

```