### PR TITLE
fix Trying to access array offset on value of type int

### DIFF
--- a/XML/Util.php
+++ b/XML/Util.php
@@ -918,7 +918,7 @@ class XML_Util
     public static function isValidName($string)
     {
         // check for invalid chars
-        if (!preg_match('/^[[:alpha:]_]\\z/', $string[0])) {
+        if (!is_string($string) || !strlen($string) || !preg_match('/^[[:alpha:]_]\\z/', $string[0])) {
             return XML_Util::raiseError(
                 'XML names may only start with letter or underscore',
                 XML_UTIL_ERROR_INVALID_START

--- a/tests/IsValidNameTests.php
+++ b/tests/IsValidNameTests.php
@@ -35,4 +35,28 @@ class IsValidNameTests extends AbstractUnitTests
         $expectedError = "XML names may only start with letter or underscore";
         $this->assertEquals($expectedError, $result->getMessage());
     }
+
+    /**
+     * @covers XML_Util::isValidName()
+     */
+    public function testIsValidNameForInt()
+    {
+        $tagName = 1;
+        $result = XML_Util::isValidName($tagName);
+        $this->assertInstanceOf('PEAR_Error', $result);
+        $expectedError = "XML names may only start with letter or underscore";
+        $this->assertEquals($expectedError, $result->getMessage());
+    }
+
+    /**
+     * @covers XML_Util::isValidName()
+     */
+    public function testIsValidNameForEmptyString()
+    {
+        $tagName = '';
+        $result = XML_Util::isValidName($tagName);
+        $this->assertInstanceOf('PEAR_Error', $result);
+        $expectedError = "XML names may only start with letter or underscore";
+        $this->assertEquals($expectedError, $result->getMessage());
+    }
 }


### PR DESCRIPTION
Discovered in XML_Serializer test suite


```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.1RC1

E.E.......E..E.EEE.....E.....E..........E.......F................ 65 / 67 ( 97%)
..                                                                67 / 67 (100%)

Time: 97 ms, Memory: 4,00MB

There were 10 errors:

1) XML_Serializer_Arrays_TestCase::testNumberedArray
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_ArraysTest.php:34

2) XML_Serializer_Arrays_TestCase::testMixedArray
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_ArraysTest.php:60

3) XML_Serializer_Option_AttributesContent_TestCase::testNumbered
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1236
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1035
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_AttributesContentTest.php:101

4) XML_Serializer_Option_ClassName_TestCase::testSimple
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_ClassNameTest.php:35

5) XML_Serializer_Option_DefaultTag_TestCase::testSimple
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_DefaultTagTest.php:35

6) XML_Serializer_Option_DefaultTag_TestCase::testContext
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1236
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1035
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_DefaultTagTest.php:53

7) XML_Serializer_Option_DefaultTag_TestCase::testMixed
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1236
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1035
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_DefaultTagTest.php:72

8) XML_Serializer_Option_EncodeFunc_TestCase::testMixed
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:959
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_EncodeFuncTest.php:56

9) XML_Serializer_Option_Mode_TestCase::testDefault
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1236
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1035
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_ModeTest.php:34

10) XML_Serializer_Option_TagMap_TestCase::testNumberedObjects
Trying to access array offset on value of type int

/usr/share/pear/XML/Util.php:921
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:1005
/dev/shm/extras/BUILDROOT/php-pear-XML-Serializer-0.21.0-7.fc29.remi.x86_64/usr/share/pear/XML/Serializer.php:728
/dev/shm/extras/BUILD/php-pear-XML-Serializer-0.21.0/XML_Serializer-0.21.0/tests/Serializer_Option_TagMapTest.php:62

```